### PR TITLE
Add `.gitattributes` to make GitHub recognize the repository as C

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure GitHub detects files as C rather than Objective-C.
+*.c linguist-language=C
+*.h linguist-language=C


### PR DESCRIPTION
Previously, GitHub recognized the header file as Objective-C. You can view the result on [my fork](https://github.com/Calinou/pl_mpeg/tree/master) as I also committed it to my `master` branch.