### PR TITLE
added proper slice guarding

### DIFF
--- a/pl_mpeg.h
+++ b/pl_mpeg.h
@@ -2574,6 +2574,7 @@ typedef struct plm_video_t {
 	int quantizer_scale;
 	int slice_begin;
 	int macroblock_address;
+	int slice_max_macroblock_address;
 
 	int mb_row;
 	int mb_col;
@@ -2939,6 +2940,7 @@ void plm_video_decode_picture(plm_video_t *self) {
 void plm_video_decode_slice(plm_video_t *self, int slice) {
 	self->slice_begin = TRUE;
 	self->macroblock_address = (slice - 1) * self->mb_width - 1;
+	self->slice_max_macroblock_address = self->macroblock_address + self->mb_width;
 
 	// Reset motion vectors and DC predictors
 	self->motion_backward.h = self->motion_forward.h = 0;
@@ -2957,7 +2959,7 @@ void plm_video_decode_slice(plm_video_t *self, int slice) {
 	do {
 		plm_video_decode_macroblock(self);
 	} while (
-		self->macroblock_address < self->mb_size - 1 &&
+		self->macroblock_address < self->slice_max_macroblock_address &&
 		plm_buffer_no_start_code(self->buffer)
 	);
 }


### PR DESCRIPTION
What is happening is that sometimes a slice boundary is blown through because the ISO spec allows for a bit of extra '0' padding at the end, but the current version of PL_MPEG is not quite handling this right. I made a patch which guards the slice boundary based on the known last macroblock address for that specific slice. Tested with several DOSBox ReelMagic MPEG assets and the MPG file posted in this ticket: https://github.com/phoboslab/pl_mpeg/issues/24