### PR TITLE
Fix memory issue of mode `PLM_BUFFER_MODE_RING`

### DIFF
--- a/pl_mpeg.h
+++ b/pl_mpeg.h
@@ -2735,6 +2735,7 @@ plm_frame_t *plm_video_decode(plm_video_t *self) {
 		) {
 			return NULL;
 		}
+		plm_buffer_discard_read_bytes(self->buffer);
 		
 		plm_video_decode_picture(self);
 


### PR DESCRIPTION
## video_buffer keep calling realloc() and keep expanding its memory usage:

In `plm_buffer_has_start_code()`, the `discard_read_bytes` is temporarily set to FALSE.

But when it goes all the way to `plm_buffer_has()`,
it will trigger the the `load_callback()`,
which is set to `plm_read_video_packet()` in `plm_init_decoders()`.

Then `plm_buffer_write()` will eventually be called when `discard_read_bytes` is set to FALSE.
Finally it causes the `video_buffer` to keep expanding.