### PR TITLE
Fix pl_mpeg_player.c not compiling on macOS

### DIFF
--- a/pl_mpeg_player.c
+++ b/pl_mpeg_player.c
@@ -55,7 +55,6 @@ steps combined.
 #if defined(__APPLE__) && defined(__MACH__)
 	// OSX
 	#include <SDL2/SDL.h>
-	#include <SDL2/SDL_opengl.h>
 	#include <OpenGL/gl.h>
 	#include <OpenGL/glext.h>
 


### PR DESCRIPTION
This pull request removes the `SDL_opengl.h` include for macOS, since it prevents `pl_mpeg_player.c` from compiling and isn't needed anyway (SDL's OpenGL context creation/loading functions aren't declared in that header).

Currently, it is included *before* the system OpenGL headers, which disables them via header guards. Since `SDL_opengl.h` only declares the legacy OpenGL 1.3 API, `pl_mpeg_player.c` can't be compiled due to missing API functions.

Moving the include to be *after* the system GL headers works, but makes it a no-op: the system headers define `__gl_h`, which causes the majority of `SDL_opengl.h` to *not* be included. (this is probably the case with other platforms as well)