### PR TITLE
Fix UBSAN left shift warnings

### DIFF
--- a/pl_mpeg.h
+++ b/pl_mpeg.h
@@ -3176,7 +3176,7 @@ int plm_video_decode_motion_vector(plm_video_t *self, int r_size, int motion) {
 	if (motion > (fscale << 4) - 1) {
 		motion -= fscale << 5;
 	}
-	else if (motion < ((-fscale) << 4)) {
+	else if (motion < (int)((unsigned)(-fscale) << 4)) {
 		motion += fscale << 5;
 	}
 
@@ -3364,7 +3364,7 @@ void plm_video_decode_block(plm_video_t *self, int block) {
 		n++;
 
 		// Dequantize, oddify, clip
-		level <<= 1;
+                level = (unsigned)level << 1;
 		if (!self->macroblock_intra) {
 			level += (level < 0 ? -1 : 1);
 		}


### PR DESCRIPTION
It is undefined behavior to left shift by a negative number. This change fixes that, by casting int to/from unsigned.