### PR TITLE
Recommend TwoLAME + 224kbps audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ not supported by this library.
 You can encode video in a suitable format using ffmpeg:
 
 ```
-ffmpeg -i input.mp4 -c:v mpeg1video -q:v 0 -c:a mp2 -format mpeg output.mpg
+ffmpeg -i input.mp4 -c:v mpeg1video -q:v 0 -c:a libtwolame -b:a 224k -format mpeg output.mpg
 ```
 
 `-q:v` sets a fixed video quality with a variable bitrate, where `0` is the 


### PR DESCRIPTION
Rule number 1 of using FFmpeg: avoid experimental encoders as much as you can. Yes, the `mp2` encoder is experimental, just like `vorbis` (you're supposed to use `libvorbis` instead). Another example could be AAC: most implementations like OBS Studio prefer `libfdk-aac` over `aac`. The resulting quality of experimental encoders is notably low even if you use the maximum possible bitrate.

I got a bit of interest in MPEG1 for games after reading [your article](https://phoboslab.org/log/2019/06/pl-mpeg-single-file-library) and finding out there is a [commercial Bink alternative](https://www.bandicam.com/company/sdk/bandi_video_library/benchmark/) that is actually just MP1 + MP2 audio.

I did a lot of FFmpeg encoding tests to push the quality/size ratio to its limits, and this is when I reminded at the last second that [TwoLAME](https://www.twolame.org/) existed and was available in FFmpeg.

By default, FFmpeg will use the `mp2` encoder, and the bitrate will be 384kbps if you don't specify. This PR just modifies the suggested command a bit to use `libtwolame`, the better MP2 Audio encoder, plus 224kbps of bitrate, which in my tests was a perceptually lossless value and a much higher quality than the former (192kbps also works, but it's the point where very high pitch sounds begin getting distorted).