### PR TITLE
Fix low volume output

### DIFF
--- a/pl_mpeg.h
+++ b/pl_mpeg.h
@@ -4133,12 +4133,12 @@ void plm_audio_decode_frame(plm_audio_t *self) {
 							? self->samples.left
 							: self->samples.right;
 						for (int j = 0; j < 32; j++) {
-							out_channel[out_pos + j] = self->U[j] / 2147418112.0f;
+							out_channel[out_pos + j] = self->U[j] / 1090519040.0f;
 						}
 					#else
 						for (int j = 0; j < 32; j++) {
 							self->samples.interleaved[((out_pos + j) << 1) + ch] = 
-								self->U[j] / 2147418112.0f;
+								self->U[j] / 1090519040.0f;
 						}
 					#endif
 				} // End of synthesis channel loop


### PR DESCRIPTION
When playing an MPEG-1 video in VLC or a FFmpeg based video player, then comparing to playing with a PL_MPEG based player, one can notice the output volume is too low.

At first I thought volume was lowered within the reference players, but turns out it was hardcoded within `pl_mpeg.h`.

I was experimenting a bit with the players, and it seems amplifying the sound by around 6dB (equivalent of multiplying each sample by 2) yields the correct value.

At some point in `plm_audio_decode_frame`, the audio sample gets divided by `2^31 - 2^16`. I modified the value to `2^30 + 2^24`. `2^30` alone sounded slightly louder than usual, so the addition makes it more precise.

It was a guess, I don't even know if it's the precisely correct value, but it gets very close to the intended volume.