### PR TITLE
Disable MSVC security warnings

### DIFF
--- a/pl_mpeg.h
+++ b/pl_mpeg.h
@@ -812,7 +812,9 @@ plm_samples_t *plm_audio_decode(plm_audio_t *self);
 #endif
 
 #define PLM_UNUSED(expr) (void)(expr)
-
+#ifdef _MSC_VER
+	#pragma warning(disable:4996)
+#endif
 
 // -----------------------------------------------------------------------------
 // plm (high-level interface) implementation


### PR DESCRIPTION
MSVC doesn't like `fopen()` and emits a warning telling to use `fopen_s()` instead.

~~The warning could be disabled by defining `_CRT_SECURE_NO_WARNINGS`, but as `fopen()` is marked as deprecated in MSVC, I think using the suggestion might safeguard it against the future.~~

~~This is the only thing MSVC complains about in this code.~~

Fixed by disabling the warning on MSVC.