### PR TITLE
Allow requesting a frame with 0.0 tick

### DIFF
--- a/pl_mpeg.h
+++ b/pl_mpeg.h
@@ -1152,7 +1152,7 @@ void plm_decode(plm_t *self, double tick) {
 	do {
 		did_decode = FALSE;
 		
-		if (decode_video && plm_video_get_time(self->video_decoder) < video_target_time) {
+		if (decode_video && plm_video_get_time(self->video_decoder) <= video_target_time) {
 			plm_frame_t *frame = plm_video_decode(self->video_decoder);
 			if (frame) {
 				self->video_decode_callback(self, frame, self->video_decode_callback_user_data);


### PR DESCRIPTION
Some players request a first frame by passing a decode call with 0.0 as its delta.

In `pl_mpeg`, however, doing so on `plm_decode()` will always return an empty frame, as it won't tell the video decoder to decode anything.

This change just enables `plm_decode()` to do so. I haven't noticed a difference on the reference players, so we might assume nothing has broken.

> I don't know if the change is valid for audio, but for my use case it doesn't do anything. Maybe I should undo it?